### PR TITLE
reference crowdin/cli directly in action.yml runs.image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -194,4 +194,4 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://crowdin/github-action:4.1.0'
+  image: 'docker://crowdin/cli:4.1.0'


### PR DESCRIPTION
you dont need to have extra dockerfile, you can reference needed image directly

```
runs:
  using: 'docker'
  image: 'docker://debian:stretch-slim'
```

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#example-using-public-docker-registry-container

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsimage